### PR TITLE
removed flags next to languages

### DIFF
--- a/ux.symfony.com/templates/ux_packages/translator.html.twig
+++ b/ux.symfony.com/templates/ux_packages/translator.html.twig
@@ -33,8 +33,8 @@
                 <label for="translator-demo-locale" class="col-3 col-form-label">Locale</label>
                 <div class="col">
                     <select id="translator-demo-locale" {{ stimulus_action('translator-demo', 'setLocale') }} class="form-select">
-                        <option value="en">🇬🇧 English</option>
-                        <option value="fr">🇫🇷 French</option>
+                        <option value="en">English</option>
+                        <option value="fr">French</option>
                     </select>
                 </div>
             </div>


### PR DESCRIPTION
citizens of many countries do NOT want some other country's flag next to text about their country or the language they speak

e.g. I live in Ireland, and having worked on several multi-language EU projects, the Irish people I spoke to did NOT want a British flag next to the English-language information about Ireland on the website pages

therefore I recommend the examples do NOT provide the flag of a country next to the name of a spoken language (even if the language did originate there historically ...)

| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no <!-- please update src/**/CHANGELOG.md files -->
| Tickets       | 
| License       | MIT

<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally (see https://symfony.com/releases):
 - Always add tests and ensure they pass.
 - Never break backward compatibility (see https://symfony.com/bc).
 - Features and deprecations must be submitted against branch main.
-->
